### PR TITLE
Add rule for ES6 arrow functions

### DIFF
--- a/eslint/eslintrc-shared.yml
+++ b/eslint/eslintrc-shared.yml
@@ -32,6 +32,9 @@ rules:
     prefer-const: 1
     require-yield: 2
 
+    # ES6 arrow functions.
+    arrow-spacing: 2
+
     # Disable a couple of the recommended checks:
 
     # Allow unused parameters. In callbacks, removing them seems to obscure
@@ -44,4 +47,3 @@ rules:
     # Well, we should start using loggers more consistently so we can turn
     # this on.
     no-console: 0
-


### PR DESCRIPTION
As y'all know, I don't like "correcting" or debating style in PRs because it seems like a frustrating way for a developer to learn the style, and a missed opportunity to address points of substance.

That said, style uniformity goes a long way toward improving readability. We're fortunate to have great tooling for this. So once we've agreed on a style, it's fairly easy to maintain, and learn.

Given that, I think it makes sense to debate the compelling style points once, and then let the checker take care of it.

With ES6 in Blue, we're starting to pull in some new syntax that is not covered by our current style rules. This is one style suggestion I'd like to make for arrow functions. It was inspired by working with real code – code I wrote for a side project and code Sasha wrote in bodylabs/skeleton-react-frontend#7.

Along the way I experimented with a custom rule for braces around multi-line lambdas. This was feasible, but I'm not convinced it's actually an improvement. If we decide later it is, or implement one for e.g. Underscore's functional style, which comes up a lot, I've got an example parked in a branch.

### Spaces around arrows

```js
e=> setRequiredInfo(filters.NAME_FILTER, e.target.value)
```
becomes
```js
e => setRequiredInfo(filters.NAME_FILTER, e.target.value)
```