### PR TITLE
Allow spaces after object method keys

### DIFF
--- a/jscs/jscsrc-shared
+++ b/jscs/jscsrc-shared
@@ -112,7 +112,7 @@
     "disallowSpacesInsideArrayBrackets": true,
     "requireSpacesInsideObjectBrackets": "all",
     "requireSpaceBeforeObjectValues": true,
-    "disallowSpaceAfterObjectKeys": true,
+    "disallowSpaceAfterObjectKeys": { "allExcept": ["method"] },
     "disallowQuotedKeysInObjects": true,
     "requireDotNotation": true,
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bodylabs-javascript-style",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Body Labs JavaScript style",
   "repository": {
     "type": "git",


### PR DESCRIPTION
We had conflicting rules regarding object method keys spaces that
made it impossible for linting to pass when using methods on a plain
JS object. This allows spaces before round braces in object methods
to remove the conflict with our other rules that require spaces.

An example of code that would never pass lint before:

```js
const x = {
  myMethod () { ... }
};
```
Regardless of whether you wrote `myMethod()` or `myMethod ()`, some linter rule would complain. Now only `myMethod ()` will pass.

@paulmelnikow