### PR TITLE
Republish config as an eslint plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@ bodylabs-javascript-style
 
 Body Labs JavaScript style, using eslint.
 
-This is provided as an eslint module, because it enables bundling together
-multiple configs, and also allows us to provide code for our own rules.
+This is provided as an eslint module, because it lets us bundle together
+multiple configs, and also allows us to provide code for our own rules,
+should we add any in the future.
 
 
 Versioning

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ extends:
 ```
 
 ```json
-  "scripts": {
-    "lint": "eslint src",
-    "unittest": "mocha src",
-    "test": "npm run lint && npm run unittest"
-  }
+"scripts": {
+  "lint": "eslint src",
+  "unittest": "mocha src",
+  "test": "npm run lint && npm run unittest"
+}
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ bodylabs-javascript-style
 
 Body Labs JavaScript style, using eslint.
 
+This is provided as an eslint module, because it enables bundling together
+multiple configs, and also allows us to provide code for our own rules.
+
 
 Versioning
 ----------

--- a/README.md
+++ b/README.md
@@ -1,11 +1,24 @@
-bodylabs-javascript-style
-=========================
+eslint-plugin-bodylabs
+======================
 
 Body Labs JavaScript style, using eslint.
 
 This is provided as an eslint module, because it lets us bundle together
 multiple configs, and also allows us to provide code for our own rules,
 should we add any in the future.
+
+
+Usage
+-----
+
+```sh
+npm install --save-dev eslint eslint-plugin-bodylabs
+```
+
+```yml
+extends:
+    "plugin:bodylabs/common"
+```
 
 
 Versioning

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 bodylabs-javascript-style
-=============
+=========================
 
-Body Labs JavaScript style, using JSCS and eslint.
+Body Labs JavaScript style, using eslint.
 
 
 Versioning

--- a/README.md
+++ b/README.md
@@ -15,9 +15,19 @@ Usage
 npm install --save-dev eslint eslint-plugin-bodylabs
 ```
 
+In your project, create `.eslintrc.yml`:
+
 ```yml
 extends:
     "plugin:bodylabs/common"
+```
+
+```json
+  "scripts": {
+    "lint": "eslint src",
+    "unittest": "mocha src",
+    "test": "npm run lint && npm run unittest"
+  }
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ extends:
     "plugin:bodylabs/common"
 ```
 
+And then set up scripts:
+
 ```json
 "scripts": {
   "lint": "eslint src",

--- a/eslint/common.yml
+++ b/eslint/common.yml
@@ -1,9 +1,6 @@
 # Body Labs JavaScript style. Derived from Crockford style, with a bunch of
 # tweaks.
 
-# Don't inherit settings from e.g. ~.
-root: true
-
 env:
     node: true
     mocha: true

--- a/index.js
+++ b/index.js
@@ -5,6 +5,13 @@ const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
 
-const eslintrcPath = path.resolve(__dirname, 'eslint', 'eslintrc-shared.yml');
+const loadConfig = (name) => {
+    const configPath = path.resolve(__dirname, 'eslint', `${ name }.yml`);
+    return yaml.load(fs.readFileSync(configPath, 'utf8'));
+};
 
-module.exports = yaml.load(fs.readFileSync(eslintrcPath, 'utf8'));
+module.exports = {
+    configs: {
+        common: loadConfig('common'),
+    },
+};

--- a/index.js
+++ b/index.js
@@ -1,0 +1,10 @@
+// Load the config from yaml, since we prefer to read yaml. Use sync methods,
+// since this module needs to export a full config.
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const eslintrcPath = path.resolve(__dirname, 'eslint', 'eslintrc-shared.yml');
+
+module.exports = yaml.load(fs.readFileSync(eslintrcPath, 'utf8'));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "bodylabs-javascript-style",
-  "version": "6.0.0",
+  "name": "eslint-config-bodylabs",
+  "version": "6.1.0",
   "description": "Body Labs JavaScript style",
   "repository": {
     "type": "git",
@@ -11,5 +11,8 @@
   "homepage": "https://github.com/bodylabs/bodylabs-javascript-style",
   "peerDependencies": {
     "eslint": ">=2.13.0"
+  },
+  "dependencies": {
+    "js-yaml": "^3.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "eslint": ">=2.13.0"
   },
   "dependencies": {
-    "js-yaml": ">3"
+    "js-yaml": ">=3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "eslint": ">=2.13.0"
   },
   "dependencies": {
-    "js-yaml": "^3.6.1"
+    "js-yaml": ">3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "Body Labs JavaScript style",
   "repository": {
     "type": "git",
-    "url": "https://github.com/bodylabs/bodylabs-javascript-style.git"
+    "url": "https://github.com/bodylabs/eslint-plugin-bodylabs.git"
   },
   "author": "Body Labs",
   "license": "MIT",
-  "homepage": "https://github.com/bodylabs/bodylabs-javascript-style",
+  "homepage": "https://github.com/bodylabs/eslint-plugin-bodylabs",
   "peerDependencies": {
     "eslint": ">=2.13.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "eslint-config-bodylabs",
-  "version": "6.1.0",
+  "name": "eslint-plugin-bodylabs",
+  "version": "7.0.0",
   "description": "Body Labs JavaScript style",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This reformats the repository to work as an eslint plugin. This approach should allow us to drop in a small eslintrc into each project:

```yml
extends:
    "plugin:bodylabs/common"
```

And then invoke `eslint` with a minimum of command-line arguments.

This also makes `eslint --fix` easy to invoke, which is really nice.

Next, since a plugin can accommodate multiple configs, we can merge [bodylabs-frontend-style](https://github.com/bodylabs/bodylabs-frontend-style) into this repo, as a second named config. That should make it simpler to pull in these configs, and easier to keep everything in sync.